### PR TITLE
Hotfix: `dist` task create zip archive incorrectly

### DIFF
--- a/dist/Taskfile.yml
+++ b/dist/Taskfile.yml
@@ -6,7 +6,7 @@ tasks:
     requires:
       vars: [TEMPLATE_NAME]
     cmds:
-      - 7zz a -tzip dist/{{.TEMPLATE_NAME}}.zip templates/{{.TEMPLATE_NAME}}/* resources/*
+      - 7zz a -tzip dist/{{.TEMPLATE_NAME}}.zip ./templates/{{.TEMPLATE_NAME}}/* ./resources/*
 
   report:
     desc: Pack report template to Zip archive

--- a/dist/Taskfile.yml
+++ b/dist/Taskfile.yml
@@ -5,6 +5,8 @@ tasks:
     internal: true
     requires:
       vars: [TEMPLATE_NAME]
+    preconditions:
+      - rm -f dist/{{.TEMPLATE_NAME}}.zip
     cmds:
       - 7zz a -tzip dist/{{.TEMPLATE_NAME}}.zip ./templates/{{.TEMPLATE_NAME}}/* ./resources/*
 


### PR DESCRIPTION
- Fix wrong command line syntax cause 7zip to create archive including parent folder
- Add pre-condition to delete previous archive if existed to ensure a new archive is created